### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @dagolav
+/.security/ @dagolav

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: 
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "datadeling_og_distribusjon"
   system: "geonorge"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_DOK.Arealanalyse.spesifikasjon"
-  title: "Security Champion DOK.Arealanalyse.spesifikasjon"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "dagolav"
-  children:
-  - "resource:DOK.Arealanalyse.spesifikasjon"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "DOK.Arealanalyse.spesifikasjon"
-  links:
-  - url: "https://github.com/kartverket/DOK.Arealanalyse.spesifikasjon"
-    title: "DOK.Arealanalyse.spesifikasjon på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_DOK.Arealanalyse.spesifikasjon"
-  dependencyOf:
-  - "component:DOK.Arealanalyse.spesifikasjon"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml